### PR TITLE
Lutaml `diagram` syntax

### DIFF
--- a/lib/lutaml/uml/class.rb
+++ b/lib/lutaml/uml/class.rb
@@ -9,7 +9,8 @@ module Lutaml
     class Class < Classifier
       class UknownMemberTypeError < StandardError; end
       attr_accessor :nested_classifier,
-                    :is_abstract
+                    :is_abstract,
+                    :type
 
       attr_reader :associations,
                   :attributes,
@@ -38,6 +39,10 @@ module Lutaml
         @associations = value.to_a.map do |attr|
           Association.new(attr.to_h.merge(owned_end: name))
         end
+      end
+
+      def members=(value)
+        []
       end
 
       def methods

--- a/lib/lutaml/uml/class.rb
+++ b/lib/lutaml/uml/class.rb
@@ -1,13 +1,12 @@
 # frozen_string_literal: true
 
-require 'lutaml/uml/classifier'
-require 'lutaml/uml/association'
-require 'lutaml/uml/top_element_attribute'
+require "lutaml/uml/classifier"
+require "lutaml/uml/association"
+require "lutaml/uml/top_element_attribute"
 
 module Lutaml
   module Uml
     class Class < Classifier
-      class UknownMemberTypeError < StandardError; end
       attr_accessor :nested_classifier,
                     :is_abstract,
                     :type
@@ -41,7 +40,7 @@ module Lutaml
         end
       end
 
-      def members=(value)
+      def members=(_value)
         []
       end
 

--- a/lib/lutaml/uml/document.rb
+++ b/lib/lutaml/uml/document.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-require 'lutaml/uml/class'
+require "lutaml/uml/class"
 
 module Lutaml
   module Uml
     class Document
-      class UknownMemberTypeError < StandardError; end
+      class UnknownMemberTypeError < StandardError; end
       include HasAttributes
 
       attr_accessor :name,
@@ -37,9 +37,9 @@ module Lutaml
       private
 
       def associtaion_type(type)
-        return 'classes' if type == 'class'
+        return "classes" if type == "class"
 
-        raise(UknownMemberTypeError, "Unknown member type: #{type}")
+        raise(UnknownMemberTypeError, "Unknown member type: #{type}")
       end
     end
   end

--- a/lib/lutaml/uml/document.rb
+++ b/lib/lutaml/uml/document.rb
@@ -5,6 +5,7 @@ require 'lutaml/uml/class'
 module Lutaml
   module Uml
     class Document
+      class UknownMemberTypeError < StandardError; end
       include HasAttributes
 
       attr_accessor :name,
@@ -20,8 +21,25 @@ module Lutaml
       end
       # rubocop:enable Rails/ActiveRecordAliases
 
+      def members=(value)
+        value
+          .to_a
+          .group_by { |attributes| attributes[:type].to_s }
+          .map do |(type, group)|
+          public_send("#{associtaion_type(type)}=", group)
+        end
+      end
+
       def classes=(value)
         @classes = value.to_a.map { |attributes| Class.new(attributes) }
+      end
+
+      private
+
+      def associtaion_type(type)
+        return 'classes' if type == 'class'
+
+        raise(UknownMemberTypeError, "Unknown member type: #{type}")
       end
     end
   end

--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'parslet'
-require 'lutaml/uml/node/document'
+require "parslet"
+require "lutaml/uml/node/document"
 
 module Lutaml
   module Uml
@@ -39,14 +39,14 @@ module Lutaml
 
         rule(:spaces) { match("\s").repeat(1) }
         rule(:spaces?) { spaces.maybe }
-        rule(:whitespace) { (match("\s") | match("\n") | str(';')).repeat(1) }
+        rule(:whitespace) { (match("\s") | match("\n") | str(";")).repeat(1) }
         rule(:whitespace?) { whitespace.maybe }
 
-        rule(:name) { match['a-zA-Z0-9_-'].repeat(1) }
+        rule(:name) { match["a-zA-Z0-9_-"].repeat(1) }
 
         rule(:class_name_chars) { match('(?:[a-zA-Z0-9_-]|\:|\.)').repeat(1) }
         rule(:class_name) do
-          class_name_chars >> (str('(') >> class_name_chars >> str(')')).maybe
+          class_name_chars >> (str("(") >> class_name_chars >> str(")")).maybe
         end
 
         # -- Field/Method
@@ -60,7 +60,7 @@ module Lutaml
 
         rule(:method_abstract) { (kw_abstract.as(:abstract) >> spaces).maybe }
         rule(:member_type) do
-          (spaces >> str(':') >> spaces >> class_name.as(:type)).maybe
+          (spaces >> str(":") >> spaces >> class_name.as(:type)).maybe
         end
 
         rule(:field_keyword) { kw_field >> spaces }
@@ -87,15 +87,15 @@ module Lutaml
         rule(:method_argument) { name.as(:name) >> member_type }
         rule(:method_arguments_inner) do
           (method_argument >>
-            (spaces? >> str(',') >> spaces? >> method_argument).repeat)
+            (spaces? >> str(",") >> spaces? >> method_argument).repeat)
             .repeat.as(:arguments)
         end
         rule(:method_arguments) do
-          (str('(') >>
+          (str("(") >>
             spaces? >>
             method_arguments_inner >>
             spaces? >>
-            str(')'))
+            str(")"))
             .maybe
         end
 
@@ -138,10 +138,10 @@ module Lutaml
         end
         rule(:relationship_type) { kw_relationship_type.as(:type) >> spaces }
         rule(:relationship_from) do
-          (spaces >> (name | str('*').repeat(1)).as(:from)).maybe
+          (spaces >> (name | str("*").repeat(1)).as(:from)).maybe
         end
         rule(:relationship_to) do
-          (spaces >> (name | str('*').repeat(1)).as(:to)).maybe
+          (spaces >> (name | str("*").repeat(1)).as(:to)).maybe
         end
         rule(:relationship_definition) do
           (relationship_directionality >>
@@ -171,10 +171,10 @@ module Lutaml
         end
         rule(:class_body) do
           spaces? >>
-            str('{') >>
+            str("{") >>
             whitespace? >>
             class_inner_definition.repeat.as(:members) >>
-            str('}')
+            str("}")
         end
         rule(:class_body?) { class_body.maybe }
         rule(:class_definition) do
@@ -198,11 +198,11 @@ module Lutaml
         end
         rule(:diagram_body) do
           spaces? >>
-            str('{') >>
+            str("{") >>
             whitespace? >>
             title_definitions? >>
             diagram_inner_definition.repeat.as(:members) >>
-            str('}')
+            str("}")
         end
         rule(:diagram_body?) { diagram_body.maybe }
         rule(:diagram_definition) do

--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -6,16 +6,23 @@ require 'lutaml/uml/node/document'
 module Lutaml
   module Uml
     module Parsers
+      # Class for parsing LutaML dsl into Lutaml::Uml::Document
       class Dsl < Parslet::Parser
+        # @param [String] io - LutaML string representation
+        #        [Hash] options - options for parsing
+        #
+        # @return [Lutaml::Uml::Document]
         def self.parse(io, options = {})
           new.parse(io, options)
         end
 
         def parse(io, options = {})
-          Node::Document.new(super)
+          ::Lutaml::Uml::Document.new(super)
         end
 
         KEYWORDS = %w[
+          diagram
+          title
           class
           interface
           abstract static
@@ -30,82 +37,185 @@ module Lutaml
           rule("kw_#{keyword}") { str(keyword) }
         end
 
-        rule(:newlines)    { (match("\n") | str(';')).repeat(1) } # TODO: Unused
-        rule(:newlines?)   { newlines.maybe } # TODO: Unused
-        rule(:spaces)      { match("\s").repeat(1) }
-        rule(:spaces?)     { spaces.maybe }
-        rule(:whitespace)  { (match("\s") | match("\n") | str(';')).repeat(1) }
+        rule(:spaces) { match("\s").repeat(1) }
+        rule(:spaces?) { spaces.maybe }
+        rule(:whitespace) { (match("\s") | match("\n") | str(';')).repeat(1) }
         rule(:whitespace?) { whitespace.maybe }
 
         rule(:name) { match['a-zA-Z0-9_-'].repeat(1) }
 
         rule(:class_name_chars) { match('(?:[a-zA-Z0-9_-]|\:|\.)').repeat(1) }
-        rule(:class_name) { class_name_chars >> (str('(') >> class_name_chars >> str(')')).maybe }
+        rule(:class_name) do
+          class_name_chars >> (str('(') >> class_name_chars >> str(')')).maybe
+        end
 
         # -- Field/Method
 
         rule(:kw_access_modifier) { kw_public | kw_protected | kw_private }
 
         rule(:member_static) { (kw_static.as(:static) >> spaces).maybe }
-        rule(:member_access) { (kw_access_modifier.as(:access) >> spaces).maybe }
+        rule(:member_access) do
+          (kw_access_modifier.as(:access) >> spaces).maybe
+        end
 
         rule(:method_abstract) { (kw_abstract.as(:abstract) >> spaces).maybe }
-        rule(:member_type)     { (spaces >> str(':') >> spaces >> class_name.as(:type)).maybe }
+        rule(:member_type) do
+          (spaces >> str(':') >> spaces >> class_name.as(:type)).maybe
+        end
 
-        rule(:field_keyword)     { kw_field >> spaces }
-        rule(:field_name)        { name.as(:name) }
+        rule(:field_keyword) { kw_field >> spaces }
+        rule(:field_name) { name.as(:name) }
         rule(:field_return_type) { member_type.maybe }
-        rule(:field_definition)  { (member_static >> member_access >> field_keyword >> field_name >> field_return_type).as(:field) }
+        rule(:field_definition) do
+          (member_static >>
+            member_access >>
+            field_keyword >>
+            field_name >>
+            field_return_type)
+            .as(:field)
+        end
 
-        rule(:method_keyword)         { kw_method >> spaces }
-        rule(:method_argument)        { name.as(:name) >> member_type }
-        rule(:method_arguments_inner) { (method_argument >> (spaces? >> str(',') >> spaces? >> method_argument).repeat).repeat.as(:arguments) }
-        rule(:method_arguments)       { (str('(') >> spaces? >> method_arguments_inner >> spaces? >> str(')')).maybe }
+        rule(:title_keyword) { kw_title >> spaces }
+        rule(:title_text) do
+          match['"'].maybe >>
+            match('[a-zA-Z0-9_-]|\s').repeat(1).as(:title) >>
+            match['"'].maybe
+        end
+        rule(:title_definition) { title_keyword >> title_text }
 
-        rule(:method_name)        { name.as(:name) }
+        rule(:method_keyword) { kw_method >> spaces }
+        rule(:method_argument) { name.as(:name) >> member_type }
+        rule(:method_arguments_inner) do
+          (method_argument >>
+            (spaces? >> str(',') >> spaces? >> method_argument).repeat)
+            .repeat.as(:arguments)
+        end
+        rule(:method_arguments) do
+          (str('(') >>
+            spaces? >>
+            method_arguments_inner >>
+            spaces? >>
+            str(')'))
+            .maybe
+        end
+
+        rule(:method_name) { name.as(:name) }
         rule(:method_return_type) { member_type.maybe }
-        rule(:method_definition)  { (method_abstract >> member_static >> member_access >> method_keyword >> method_name >> method_arguments >> method_return_type).as(:method) }
+        rule(:method_definition) do
+          (method_abstract >>
+            member_static >>
+            member_access >>
+            method_keyword >>
+            method_name >>
+            method_arguments >>
+            method_return_type)
+            .as(:method)
+        end
 
         # -- Class Relationship
 
         rule(:kw_class_relationship_type) { kw_generalizes | kw_realizes }
 
-        rule(:class_relationship_type)       { kw_class_relationship_type.as(:type) >> spaces }
-        rule(:class_relationship_definition) { (class_relationship_type >> class_name.as(:name)).as(:class_relationship) }
+        rule(:class_relationship_type) do
+          kw_class_relationship_type.as(:type) >> spaces
+        end
+        rule(:class_relationship_definition) do
+          (class_relationship_type >> class_name.as(:name))
+            .as(:class_relationship)
+        end
 
         # -- Relationship
 
-        rule(:kw_relationship_directionality) { kw_directional | kw_bidirectional }
-        rule(:kw_relationship_type)           { kw_dependency | kw_association | kw_aggregation | kw_composition }
+        rule(:kw_relationship_directionality) do
+          kw_directional | kw_bidirectional
+        end
+        rule(:kw_relationship_type) do
+          kw_dependency | kw_association | kw_aggregation | kw_composition
+        end
 
-        rule(:relationship_directionality) { (kw_relationship_directionality.as(:directionality) >> spaces).maybe }
-        rule(:relationship_type)           { kw_relationship_type.as(:type) >> spaces }
-        rule(:relationship_from)           { (spaces >> (name | str('*').repeat(1)).as(:from)).maybe }
-        rule(:relationship_to)             { (spaces >> (name | str('*').repeat(1)).as(:to)).maybe }
-        rule(:relationship_definition)     { (relationship_directionality >> relationship_type >> class_name.as(:name) >> relationship_from >> relationship_to).as(:relationship) }
+        rule(:relationship_directionality) do
+          (kw_relationship_directionality.as(:directionality) >> spaces).maybe
+        end
+        rule(:relationship_type) { kw_relationship_type.as(:type) >> spaces }
+        rule(:relationship_from) do
+          (spaces >> (name | str('*').repeat(1)).as(:from)).maybe
+        end
+        rule(:relationship_to) do
+          (spaces >> (name | str('*').repeat(1)).as(:to)).maybe
+        end
+        rule(:relationship_definition) do
+          (relationship_directionality >>
+            relationship_type >>
+            class_name.as(:name) >>
+            relationship_from >>
+            relationship_to)
+            .as(:relationship)
+        end
 
         # -- Class
 
         rule(:kw_class_modifier) { kw_abstract | kw_interface }
 
-        rule(:class_modifier)          { (kw_class_modifier.as(:modifier) >> spaces).maybe }
-        rule(:class_keyword)           { kw_class >> spaces }
-        rule(:class_inner_definitions) { field_definition | method_definition | class_relationship_definition | relationship_definition }
-        rule(:class_inner_definition)  { class_inner_definitions >> whitespace? }
-        rule(:class_body)              { spaces? >> str('{') >> whitespace? >> class_inner_definition.repeat.as(:members) >> str('}') }
-        rule(:class_body?)             { class_body.maybe }
+        rule(:class_modifier) do
+          (kw_class_modifier.as(:modifier) >> spaces).maybe
+        end
+        rule(:class_keyword) { kw_class.as(:type) >> spaces }
+        rule(:class_inner_definitions) do
+          field_definition |
+            method_definition |
+            class_relationship_definition |
+            relationship_definition
+        end
+        rule(:class_inner_definition) do
+          class_inner_definitions >> whitespace?
+        end
+        rule(:class_body) do
+          spaces? >>
+            str('{') >>
+            whitespace? >>
+            class_inner_definition.repeat.as(:members) >>
+            str('}')
+        end
+        rule(:class_body?) { class_body.maybe }
+        rule(:class_definition) do
+          class_modifier >>
+            class_keyword >>
+            class_name.as(:name) >>
+            class_body?
+        end
 
-        rule(:class_definition) { class_modifier >> class_keyword >> class_name.as(:name) >> class_body? }
+        # -- Diagram
 
-        # -- Document
-
-        rule(:document_definitions) { class_definition >> whitespace? }
-
-        rule(:document) { whitespace? >> document_definitions.repeat.as(:classes) }
-
+        rule(:diagram_keyword) { kw_diagram >> spaces? }
+        rule(:diagram_inner_definitions) do
+          title_definition | class_definition | relationship_definition
+        end
+        rule(:diagram_inner_definition) do
+          diagram_inner_definitions >> whitespace?
+        end
+        rule(:title_definitions?) do
+          (title_definition >> whitespace?).maybe
+        end
+        rule(:diagram_body) do
+          spaces? >>
+            str('{') >>
+            whitespace? >>
+            title_definitions? >>
+            diagram_inner_definition.repeat.as(:members) >>
+            str('}')
+        end
+        rule(:diagram_body?) { diagram_body.maybe }
+        rule(:diagram_definition) do
+          diagram_keyword >>
+            spaces? >>
+            class_name.as(:name) >>
+            diagram_body?
+        end
+        rule(:diagram_definitions) { diagram_definition >> whitespace? }
+        rule(:diagram) { whitespace? >> diagram_definition }
         # -- Root
 
-        root(:document)
+        root(:diagram)
       end
     end
   end

--- a/spec/fixtures/dsl/diagram.lutaml
+++ b/spec/fixtures/dsl/diagram.lutaml
@@ -1,0 +1,3 @@
+diagram MyView {
+  class Foo {}
+}

--- a/spec/fixtures/dsl/diagram_attributes.lutaml
+++ b/spec/fixtures/dsl/diagram_attributes.lutaml
@@ -1,0 +1,4 @@
+diagram MyView {
+  title "my diagram"
+  class Foo {}
+}

--- a/spec/fixtures/dsl/diagram_multiply_classes.lutaml
+++ b/spec/fixtures/dsl/diagram_multiply_classes.lutaml
@@ -1,0 +1,6 @@
+diagram MyView {
+  title "my diagram"
+  class Foo {}
+  class Doo {}
+  class Koo {}
+}

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Lutaml::Uml::Parsers::Dsl do
+  describe '.parse' do
+    subject(:parse) { described_class.parse(conent) }
+
+    context 'when simple diagram without attributes' do
+      let(:conent) do
+        File.read(fixtures_path('dsl/diagram.lutaml'))
+      end
+
+      it 'creates Lutaml::Uml::Document object from supplied dsl' do
+        expect(parse).to be_instance_of(Lutaml::Uml::Document)
+      end
+    end
+
+    context 'when diagram with attributes' do
+      let(:conent) do
+        File.read(fixtures_path('dsl/diagram_attributes.lutaml'))
+      end
+
+      it 'creates Lutaml::Uml::Document object and sets its attributes' do
+        expect(parse).to be_instance_of(Lutaml::Uml::Document)
+        expect(parse.title).to eq("my diagram")
+      end
+    end
+
+    context 'when multiply classes entries' do
+      let(:conent) do
+        File.read(fixtures_path('dsl/diagram_multiply_classes.lutaml'))
+      end
+
+      it 'creates Lutaml::Uml::Document object and creates dependent classes' do
+        expect(parse).to be_instance_of(Lutaml::Uml::Document)
+        expect(parse.classes.length).to eq(3)
+      end
+    end
+  end
+end

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -1,38 +1,38 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe Lutaml::Uml::Parsers::Dsl do
-  describe '.parse' do
+  describe ".parse" do
     subject(:parse) { described_class.parse(conent) }
 
-    context 'when simple diagram without attributes' do
+    context "when simple diagram without attributes" do
       let(:conent) do
-        File.read(fixtures_path('dsl/diagram.lutaml'))
+        File.read(fixtures_path("dsl/diagram.lutaml"))
       end
 
-      it 'creates Lutaml::Uml::Document object from supplied dsl' do
+      it "creates Lutaml::Uml::Document object from supplied dsl" do
         expect(parse).to be_instance_of(Lutaml::Uml::Document)
       end
     end
 
-    context 'when diagram with attributes' do
+    context "when diagram with attributes" do
       let(:conent) do
-        File.read(fixtures_path('dsl/diagram_attributes.lutaml'))
+        File.read(fixtures_path("dsl/diagram_attributes.lutaml"))
       end
 
-      it 'creates Lutaml::Uml::Document object and sets its attributes' do
+      it "creates Lutaml::Uml::Document object and sets its attributes" do
         expect(parse).to be_instance_of(Lutaml::Uml::Document)
         expect(parse.title).to eq("my diagram")
       end
     end
 
-    context 'when multiply classes entries' do
+    context "when multiply classes entries" do
       let(:conent) do
-        File.read(fixtures_path('dsl/diagram_multiply_classes.lutaml'))
+        File.read(fixtures_path("dsl/diagram_multiply_classes.lutaml"))
       end
 
-      it 'creates Lutaml::Uml::Document object and creates dependent classes' do
+      it "creates Lutaml::Uml::Document object and creates dependent classes" do
         expect(parse).to be_instance_of(Lutaml::Uml::Document)
         expect(parse.classes.length).to eq(3)
       end


### PR DESCRIPTION
lutaml/lutaml-uml#37 Support for `diagram` tag attribute lutaml syntax, rubocop fixes for lib/lutaml/uml/parsers/dsl.rb file