### PR TITLE
Hotfix/Dont use `GraphViz` renderer

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -31,6 +31,8 @@ jobs:
         run: |
           sudo gem install bundler --force
           bundle install --jobs 4 --retry 3
+      - name: Install Grpahviz macOS
+        run: brew install graphviz
       - name: Run specs
         run: |
           bundle exec rake

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -33,6 +33,8 @@ jobs:
         run: |
           gem install bundler
           bundle install --jobs 4 --retry 3
+      - name: Install Grpahviz Ubuntu
+        run: sudo apt-get install graphviz
       - name: Run specs
         run: |
           bundle exec rake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,6 +36,9 @@ jobs:
           gem install bundler
           bundle config --local path vendor/bundle
           bundle install --jobs 4 --retry 3
+      - name: Install Grpahviz Windows
+        run: |
+          cinst -y graphviz
       - name: Run specs
         run: |
           bundle exec rake

--- a/lib/lutaml/layout/graph_viz_engine.rb
+++ b/lib/lutaml/layout/graph_viz_engine.rb
@@ -7,21 +7,12 @@ module Lutaml
   module Layout
     class GraphVizEngine < Engine
       def render(type)
-        parse_graphviz_string
-          .output(type => String)
-      end
-
-      private
-
-      # GraphViz#parse_string and GraphViz#parse crush with no reason
-      # with seg fault, this lead to nil return value.
-      # Try to recall method several time
-      def parse_graphviz_string(attempts = 10)
-        raise('Cannot parse input string, `gvpr` segmentation fault?') if attempts == 0
-        res = GraphViz.parse_string(input)
-        return res if res
-
-        parse_graphviz_string(attempts - 1)
+        Open3.popen3("dot -T#{type}") do |stdin, stdout, _stderr, _wait|
+          stdin.puts(input)
+          stdin.close
+          # unless (err = stderr.read).empty? then raise err end
+          stdout.read
+        end
       end
     end
   end

--- a/spec/lutaml/layout/graph_viz_engine_spec.rb
+++ b/spec/lutaml/layout/graph_viz_engine_spec.rb
@@ -12,18 +12,18 @@ RSpec.describe Lutaml::Layout::GraphVizEngine do
     end
 
     context "when png output type" do
-      let(:type) { 'png' }
+      let(:type) { "png" }
       let(:png_header) { "\x89PNG" }
 
-      it 'renders input as png binary string' do
+      it "renders input as png binary string" do
         expect(render[0..3]).to(eq(png_header))
       end
     end
 
     context "when dot output type" do
-      let(:type) { 'dot' }
+      let(:type) { "dot" }
 
-      it 'renders input as dot string' do
+      it "renders input as dot string" do
         expect(render).to(match("digraph G {"))
       end
     end

--- a/spec/lutaml/layout/graph_viz_engine_spec.rb
+++ b/spec/lutaml/layout/graph_viz_engine_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe Lutaml::Layout::GraphVizEngine do
+  describe "#render" do
+    subject(:render) do
+      described_class.new(input: input).render(type)
+    end
+    let(:input) do
+      File.read(fixtures_path("generated_dot/AddressClassProfile.dot"))
+    end
+
+    context "when png output type" do
+      let(:type) { 'png' }
+      let(:png_header) { "\x89PNG" }
+
+      it 'renders input as png binary string' do
+        expect(render[0..3]).to(eq(png_header))
+      end
+    end
+
+    context "when dot output type" do
+      let(:type) { 'dot' }
+
+      it 'renders input as dot string' do
+        expect(render).to(match("digraph G {"))
+      end
+    end
+  end
+end


### PR DESCRIPTION
Dont use `GraphViz` for parsing and renering of dot strings, use `dot` command directly