### PR TITLE
(Hotfix) Nokogiri should be runtime_dependency

### DIFF
--- a/lutaml-uml.gemspec
+++ b/lutaml-uml.gemspec
@@ -28,10 +28,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "parslet", "~> 1.7.1"
   spec.add_runtime_dependency "ruby-graphviz", "~> 1.2"
   spec.add_runtime_dependency "thor", "~> 1.0"
+  spec.add_runtime_dependency "nokogiri", "~> 1.10"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency "nokogiri", "~> 1.10"
   spec.add_development_dependency "pry", "~> 0.12.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
https://github.com/lutaml/lutaml-xmi/issues/6 nokogiri as runtime dependency