### PR TITLE
(Hotfix) support for blank definitions blocks

### DIFF
--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -292,9 +292,7 @@ module Lutaml
             str("definition") >>
             whitespace? >>
             str("{") >>
-            whitespace? >>
-            (match("[\n\s]}").absent? >> any).repeat.as(:definition) >>
-            whitespace? >>
+            ((str('\\') >> any) | (str('}').absent? >> any)).repeat.maybe.as(:definition) >>
             str('}')
         end
 

--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -292,7 +292,7 @@ module Lutaml
             str("definition") >>
             whitespace? >>
             str("{") >>
-            ((str('\\') >> any) | (str('}').absent? >> any)).repeat.maybe.as(:definition) >>
+            ((str("\\") >> any) | (str("}").absent? >> any)).repeat.maybe.as(:definition) >>
             str('}')
         end
 

--- a/spec/fixtures/dsl/diagram_blank_definion.lutaml
+++ b/spec/fixtures/dsl/diagram_blank_definion.lutaml
@@ -1,0 +1,6 @@
+diagram MyView {
+  class ImageMapAreaType {
+    definition {
+    }
+  }
+}

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -287,5 +287,15 @@ RSpec.describe Lutaml::Uml::Parsers::Dsl do
 
       it_behaves_like "the correct graphviz formatting"
     end
+
+    context "when defninition is blank" do
+      let(:content) do
+        File.new(fixtures_path("dsl/diagram_blank_definion.lutaml"))
+      end
+
+      it "successfully renders" do
+        expect { parse }.to_not(raise_error)
+      end
+    end
   end
 end


### PR DESCRIPTION
 https://github.com/lutaml/lutaml-uml/issues/67 support blank blocks for definitions, definition parse rule refactoring