### PR TITLE
(Feature) Parsing failure of files should provide better messages 

### DIFF
--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -9,17 +9,18 @@ require "lutaml/uml/node/document"
 module Lutaml
   module Uml
     module Parsers
+      class ParsingError < StandardError; end
       # Class for parsing LutaML dsl into Lutaml::Uml::Document
       class Dsl < Parslet::Parser
         # @param [String] io - LutaML string representation
         #        [Hash] options - options for parsing
         #
         # @return [Lutaml::Uml::Document]
-        def self.parse(io, options = {}, stdout = STDOUT)
-          new.parse(io, options, stdout)
+        def self.parse(io, options = {})
+          new.parse(io, options)
         end
 
-        def parse(input_file, _options = {}, stdout = STDOUT)
+        def parse(input_file, _options = {})
           data = Lutaml::Uml::Parsers::DslPreprocessor.call(input_file)
           # https://kschiess.github.io/parslet/tricks.html#Reporter engines
           # Parslet::ErrorReporter::Deepest allows more detailed display of error
@@ -28,8 +29,7 @@ module Lutaml
                   .new
                   .apply(super(data, reporter: Parslet::ErrorReporter::Deepest.new)))
         rescue Parslet::ParseFailed => error
-          stdout.puts(error.parse_failure_cause.ascii_tree)
-          raise
+          raise ParsingError, "#{error.message}\ncause: #{error.parse_failure_cause.ascii_tree}"
         end
 
         KEYWORDS = %w[

--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "parslet"
-require 'parslet/convenience'
+require "parslet/convenience"
 require "lutaml/uml/parsers/dsl_preprocessor"
 require "lutaml/uml/parsers/dsl_transform"
 require "lutaml/uml/node/document"
@@ -23,13 +23,14 @@ module Lutaml
         def parse(input_file, _options = {})
           data = Lutaml::Uml::Parsers::DslPreprocessor.call(input_file)
           # https://kschiess.github.io/parslet/tricks.html#Reporter engines
-          # Parslet::ErrorReporter::Deepest allows more detailed display of error
+          # Parslet::ErrorReporter::Deepest allows more
+          # detailed display of error
+          reporter = Parslet::ErrorReporter::Deepest.new
           ::Lutaml::Uml::Document
-            .new(DslTransform
-                  .new
-                  .apply(super(data, reporter: Parslet::ErrorReporter::Deepest.new)))
-        rescue Parslet::ParseFailed => error
-          raise ParsingError, "#{error.message}\ncause: #{error.parse_failure_cause.ascii_tree}"
+            .new(DslTransform.new.apply(super(data, reporter: reporter)))
+        rescue Parslet::ParseFailed => e
+          raise(ParsingError,
+            "#{e.message}\ncause: \#{e.parse_failure_cause.ascii_tree}")
         end
 
         KEYWORDS = %w[

--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -30,7 +30,7 @@ module Lutaml
             .new(DslTransform.new.apply(super(data, reporter: reporter)))
         rescue Parslet::ParseFailed => e
           raise(ParsingError,
-            "#{e.message}\ncause: \#{e.parse_failure_cause.ascii_tree}")
+                "#{e.message}\ncause: #{e.parse_failure_cause.ascii_tree}")
         end
 
         KEYWORDS = %w[

--- a/lutaml-uml.gemspec
+++ b/lutaml-uml.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = %w[lutaml-wsd2uml lutaml-yaml2uml]
 
   spec.add_runtime_dependency "hashie", "~> 4.1.0"
-  spec.add_runtime_dependency "parslet"
+  spec.add_runtime_dependency "parslet", "~> 2.0.0"
   spec.add_runtime_dependency "ruby-graphviz", "~> 1.2"
   spec.add_runtime_dependency "thor", "~> 1.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.10"

--- a/lutaml-uml.gemspec
+++ b/lutaml-uml.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = %w[lutaml-wsd2uml lutaml-yaml2uml]
 
   spec.add_runtime_dependency "hashie", "~> 4.1.0"
-  spec.add_runtime_dependency "parslet", "~> 1.7.1"
+  spec.add_runtime_dependency "parslet"
   spec.add_runtime_dependency "ruby-graphviz", "~> 1.2"
   spec.add_runtime_dependency "thor", "~> 1.0"
   spec.add_runtime_dependency "nokogiri", "~> 1.10"

--- a/spec/fixtures/dsl/broken_diagram.lutaml
+++ b/spec/fixtures/dsl/broken_diagram.lutaml
@@ -1,0 +1,34 @@
+diagram MyView {
+  title "my diagram"
+
+  class AddressClassProfile {
+    addressClassProfile
+  }
+  class AttributeProfile {
+    attributeProfile
+  }
+
+  association BidirectionalAsscoiation {
+    owner_type aggregation
+    member_type direct
+    owner AddressClassProfile#addressClassProfile
+    member AttributeProfile#attributeProfile [0..*]
+  }
+
+  association DirectAsscoiation {
+    member_type direct
+    owner AddressClassProfile
+    member AttributeProfile#attributeProfile
+  }
+
+  class Foo {
+    +structuredidentifier[0..*]: StructuredIdentifierType
+    +technicalcommittee[1..*]: TechnicalCommitteeType
+  }
+
+  association ReverseAsscoiation {
+    owner_type aggregation
+    owner AddressClassProfile#addressClassProfile
+    member AttributeProfile
+  }
+}

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -322,13 +322,10 @@ RSpec.describe Lutaml::Uml::Parsers::Dsl do
       let(:content) do
         File.new(fixtures_path("dsl/broken_diagram.lutaml"))
       end
-      let(:stdout) { StringIO.new }
 
       it "returns error object and prints line number" do
-        expect { described_class.parse(content, {}, stdout) }
-          .to(raise_error(Parslet::ParseFailed))
-        stdout.rewind
-        expect(stdout.read).to(match('but got ":" at line 25 char 32'))
+        expect { described_class.parse(content, {}) }
+          .to(raise_error(Lutaml::Uml::Parsers::ParsingError, /but got ":" at line 25 char 32/))
       end
     end
   end

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -317,5 +317,19 @@ RSpec.describe Lutaml::Uml::Parsers::Dsl do
         expect { parse }.to_not(raise_error)
       end
     end
+
+    context "when broken lutaml file passed" do
+      let(:content) do
+        File.new(fixtures_path("dsl/broken_diagram.lutaml"))
+      end
+      let(:stdout) { StringIO.new }
+
+      it "returns error object and prints line number" do
+        expect { described_class.parse(content, {}, stdout) }
+          .to(raise_error(Parslet::ParseFailed))
+        stdout.rewind
+        expect(stdout.read).to(match('but got ":" at line 25 char 32'))
+      end
+    end
   end
 end

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -325,7 +325,8 @@ RSpec.describe Lutaml::Uml::Parsers::Dsl do
 
       it "returns error object and prints line number" do
         expect { described_class.parse(content, {}) }
-          .to(raise_error(Lutaml::Uml::Parsers::ParsingError, /but got ":" at line 25 char 32/))
+          .to(raise_error(Lutaml::Uml::Parsers::ParsingError,
+              /but got ":" at line 25 char 32/))
       end
     end
   end


### PR DESCRIPTION
https://github.com/lutaml/lutaml-uml/issues/71 update to the latest parslet version(2.0.0), use Parslet::ErrorReporter::Deepest for error report, display the actual error place.

After that the error display became something like this:
```bash
$: bundle exec ./exe/lutaml -t png -o OfferingDoc_DataTypes.png /Users/mikhailtretiakov/Work/Personal/Metanorma/lutaml-uml/spec/fixtures/dsl/broken_diagram.lutaml
bundler: failed to load command: ./exe/lutaml (./exe/lutaml)
Lutaml::Uml::Parsers::ParsingError: Failed to match sequence (WHITESPACE? DIAGRAM_DEFINITION) at line 1 char 1.
cause: Failed to match sequence (WHITESPACE? DIAGRAM_DEFINITION) at line 1 char 1.
`- Failed to match sequence (DIAGRAM_KEYWORD SPACES? name:CLASS_NAME DIAGRAM_BODY WHITESPACE?) at line 1 char 16.
   `- Failed to match sequence (SPACES? '{' WHITESPACE? members:(DIAGRAM_INNER_DEFINITION{0, }) '}') at line 24 char 13.
      `- Expected "}", but got ":" at line 25 char 32.

  /Users/mikhailtretiakov/Work/Personal/Metanorma/lutaml-uml/lib/lutaml/uml/parsers/dsl.rb:32:in `rescue in parse'
  /Users/mikhailtretiakov/Work/Personal/Metanorma/lutaml-uml/lib/lutaml/uml/parsers/dsl.rb:23:in `parse'
  /Users/mikhailtretiakov/Work/Personal/Metanorma/lutaml-uml/lib/lutaml/uml/parsers/dsl.rb:20:in `parse'
  /Users/mikhailtretiakov/Work/Personal/Metanorma/lutaml/lib/lutaml/parser.rb:47:in `block in parse_into_document'
```
The script will point to the exact place where the error occurred.

