### PR TITLE
(Hotfix) Commented "includes" should not be parsed

### DIFF
--- a/lib/lutaml/uml/parsers/dsl_preprocessor.rb
+++ b/lib/lutaml/uml/parsers/dsl_preprocessor.rb
@@ -28,7 +28,7 @@ module Lutaml
 
         def process_include_line(include_root, line)
           include_path_match = line.match(/^\s*include\s+(.+)/)
-          return line if include_path_match.nil?
+          return line if include_path_match.nil? || line =~ /^\s\*\*/
 
           path_to_file = include_path_match[1].strip
           path_to_file = if path_to_file.match?(/^\//)

--- a/spec/fixtures/dsl/diagram_blank_entities.lutaml
+++ b/spec/fixtures/dsl/diagram_blank_entities.lutaml
@@ -1,0 +1,8 @@
+diagram MyView {
+  class ImageMapAreaType {
+  }
+  enum SomeEnum { 
+  }
+  data_type SomeEnum {
+  }
+}

--- a/spec/fixtures/dsl/diagram_commented_includes.lutaml
+++ b/spec/fixtures/dsl/diagram_commented_includes.lutaml
@@ -1,0 +1,5 @@
+diagram MyView {
+  title "my diagram"
+
+  ** include ../models/bipm_document/BipmCommitteeAcronym.lutaml
+}

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -297,5 +297,25 @@ RSpec.describe Lutaml::Uml::Parsers::Dsl do
         expect { parse }.to_not(raise_error)
       end
     end
+
+    context "when there are blank definitions" do
+      let(:content) do
+        File.new(fixtures_path("dsl/diagram_blank_entities.lutaml"))
+      end
+
+      it "successfully renders" do
+        expect { parse }.to_not(raise_error)
+      end
+    end
+
+    context "when there are commented preprocessor lines" do
+      let(:content) do
+        File.new(fixtures_path("dsl/diagram_commented_includes.lutaml"))
+      end
+
+      it "successfully renders" do
+        expect { parse }.to_not(raise_error)
+      end
+    end
   end
 end


### PR DESCRIPTION
    https://github.com/lutaml/lutaml-uml/issues/76 ignore commented out lines during preprocessing