### PR TITLE
(Hotfix) support for additional symbols, caption, title attributes

### DIFF
--- a/lib/lutaml/uml/parsers/dsl.rb
+++ b/lib/lutaml/uml/parsers/dsl.rb
@@ -151,14 +151,14 @@ module Lutaml
         rule(:title_keyword) { kw_title >> spaces }
         rule(:title_text) do
           match['"\''].maybe >>
-            match['a-zA-Z0-9_\- '].repeat(1).as(:title) >>
+            match['a-zA-Z0-9_\- ,.:;'].repeat(1).as(:title) >>
             match['"\''].maybe
         end
         rule(:title_definition) { title_keyword >> title_text }
         rule(:caption_keyword) { kw_caption >> spaces }
         rule(:caption_text) do
           match['"\''].maybe >>
-            match['a-zA-Z0-9_\- '].repeat(1).as(:caption) >>
+            match['a-zA-Z0-9_\- ,.:;'].repeat(1).as(:caption) >>
             match['"\''].maybe
         end
         rule(:caption_definition) { caption_keyword >> caption_text }

--- a/spec/fixtures/dsl/diagram_attributes.lutaml
+++ b/spec/fixtures/dsl/diagram_attributes.lutaml
@@ -1,5 +1,6 @@
 diagram MyView {
   fontname "Arial"
-  title "my diagram"
+  title "my diagram, another symbols: text."
   class Foo {}
+  caption "Block elements of StandardDocument, adapted from BasicDocument. Another - symbol"
 }

--- a/spec/lutaml/uml/parsers/dsl_spec.rb
+++ b/spec/lutaml/uml/parsers/dsl_spec.rb
@@ -34,7 +34,9 @@ RSpec.describe Lutaml::Uml::Parsers::Dsl do
 
       it "creates Lutaml::Uml::Document object and sets its attributes" do
         expect(parse).to be_instance_of(Lutaml::Uml::Document)
-        expect(parse.title).to eq("my diagram")
+        expect(parse.title).to eq("my diagram, another symbols: text.")
+        expect(parse.caption)
+          .to(eq("Block elements of StandardDocument, adapted from BasicDocument. Another - symbol"))
         expect(parse.fontname).to eq("Arial")
       end
 


### PR DESCRIPTION
https://github.com/metanorma/metanorma-plugin-lutaml/issues/39 add support for additional symbols(,.:;) for caption and title attributes.