### PR TITLE
refactor: consolidate architecture friction (ModelHelpers, registries, forbidden patterns)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,9 @@
 # CLAUDE.md — Lutaml::Uml Gem
 
 ## Project Overview
-`lutaml-uml` provides UML domain models, a repository pattern for querying/presenting UML documents, format converters, EA diagram rendering, and a Vue.js SPA static site generator. It is the core UML library used by the `lutaml` gem.
+`lutaml-uml` provides UML domain models, a repository pattern for querying/presenting UML documents, LUR (`.lur`) package serialization, and a Vue.js SPA static site generator. It is the core UML library used by the `lutaml` meta-bundle.
+
+Sparx EA parsing (QEA, XMI), EA diagram SVG rendering, and the EA → UML bridge live in the companion **`ea`** gem (`https://github.com/lutaml/ea`), which depends on this gem. The XMI schema models live in the **`xmi`** gem (`https://github.com/lutaml/xmi`), used solely by `ea`.
 
 ## Testing Constraints
 
@@ -27,20 +29,24 @@ require "lutaml/uml"
 require "lutaml/uml_repository"
 ```
 
-For code in the **lutaml** gem (xmi, formatter), use `require` — it's a dev dependency:
-```ruby
-require "lutaml/formatter"
-require "lutaml/xmi"
-```
-
 ## Architecture
 - `lib/lutaml/uml/` — UML domain models (Class, Association, Package, DataType, Enum, etc.)
 - `lib/lutaml/uml_repository/` — Repository pattern (queries, presenters, exporters, SPA, web UI)
-- `lib/lutaml/converter/` — Format converters (XMI→UML, DSL→UML)
-- `lib/lutaml/ea/` — EA diagram SVG rendering
 - `frontend/` — Vue 3 SPA frontend (pre-built dist checked in)
 - `templates/` — Liquid templates for web UI
 - `config/` — Default SPA configuration
+
+## Sibling gems (separate repos)
+
+| Gem | Direction | Purpose |
+|-----|-----------|---------|
+| `ea` | depends on us | Sparx EA parsing (QEA, XMI), diagram rendering, EA → UML bridge |
+| `xmi` | used only by `ea` | XMI/UML schema models (`Xmi::Sparx::Root`, `Xmi::Uml::*`) |
+| `lutaml-model` | we depend on it | Serialization framework |
+| `lutaml-lml` | depends on us | LML DSL for authoring UML models |
+| `lutaml` | meta-bundle | Bundles `lutaml-uml` + `lutaml-lml` + parsers |
+
+Local development: the `Gemfile` auto-detects `../ea` and uses the local checkout when present (monorepo-style workflow). Set `EA_FORCE_RUBYGEMS=1` to test against the published version.
 
 ## SPA Static Site Generator
 The SPA generator uses typed models + strategy pattern:

--- a/Gemfile
+++ b/Gemfile
@@ -4,17 +4,18 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "lutaml-model", github: "lutaml/lutaml-model", branch: "main"
+# Sibling-repo path dependencies — used during local development when
+# the sibling checkout exists (monorepo-style workflow). In CI and for
+# gem install, fall back to the published rubygems versions.
+%w[lutaml-model ea].each do |sibling_gem|
+  sibling_path = File.expand_path("../#{sibling_gem}", __dir__)
+  if File.directory?(sibling_path)
+    gem sibling_gem, path: sibling_path
+  else
+    gem sibling_gem
+  end
+end
+
 gem "rack-test"
 gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
-
-# Sibling-repo path dependency — used during local development when
-# the sibling checkout exists (monorepo-style workflow). In CI and for
-# gem install, fall back to the published rubygems version.
-ea_path = File.expand_path("../ea", __dir__)
-if File.directory?(ea_path)
-  gem "ea", path: ea_path
-else
-  gem "ea"
-end

--- a/lib/lutaml/uml/package_walker.rb
+++ b/lib/lutaml/uml/package_walker.rb
@@ -2,11 +2,23 @@
 
 module Lutaml
   module Uml
+    # Walks a Document or Package tree, yielding elements of each declared
+    # collection type together with their containing package path.
+    #
+    # Walk target must be a {Document} or {Package}. The +types+ argument
+    # declares which collection readers to visit; only known readers are
+    # dispatched so the walk is type-safe.
     class PackageWalker
-      # Yield each element of the specified types from a document or package hierarchy.
+      # Reader method names that may be visited during a walk. A node's
+      # reader is only called when the node's class actually defines it
+      # via the type hierarchy (Document or Package).
+      TYPES = %i[classes data_types enums associations packages].freeze
+
+      # Yield each element of the specified types from a document or
+      # package hierarchy.
       #
-      # @param root [Lutaml::Uml::Document, Lutaml::Uml::Package] The root to walk
-      # @param types [Array<Symbol>] Which collections to visit (:classes, :data_types, :enums, :associations, :packages)
+      # @param root [Lutaml::Uml::Document, Lutaml::Uml::Package] The root
+      # @param types [Array<Symbol>] Subset of {TYPES} to visit
       # @yield [element, package_path] Each element found and its package path
       def self.each_element(root, types: [:classes], &block)
         new(root, types: types).each_element(&block)
@@ -14,8 +26,8 @@ module Lutaml
 
       # Collect all elements as a flat array.
       #
-      # @param root [Lutaml::Uml::Document, Lutaml::Uml::Package] The root to walk
-      # @param types [Array<Symbol>] Which collections to visit
+      # @param root [Lutaml::Uml::Document, Lutaml::Uml::Package] The root
+      # @param types [Array<Symbol>] Subset of {TYPES} to visit
       # @return [Array] Flat array of [element, package_path] pairs
       def self.collect(root, types: [:classes])
         results = []
@@ -28,27 +40,46 @@ module Lutaml
         @types = types
       end
 
-      def each_element(&block)
-        walk(@root, "", &block)
+      def each_element
+        walk(@root, "") { |element, path| yield element, path }
+      end
 
       private
 
       def walk(node, current_path)
         @types.each do |type|
-          next unless node.respond_to?(type)
+          next unless TYPES.include?(type)
+          next unless walkable?(node)
 
           collection = node.public_send(type)
           next unless collection
 
-          collection.each do |element|
-            yield element, current_path
+          collection.each { |element| yield element, current_path }
+        end
 
-        # Recurse into sub-packages
-        return unless node.respond_to?(:packages)
+        recurse_into_packages(node, current_path)
+      end
+
+      # Recurse into sub-packages. Yields nothing if the node cannot
+      # own packages.
+      def recurse_into_packages(node, current_path)
+        return unless walkable?(node)
 
         packages = node.packages
         return unless packages
 
         packages.each do |pkg|
           pkg_path = current_path.empty? ? pkg.name.to_s : "#{current_path}::#{pkg.name}"
-          walk(pkg, pkg_path)
+          walk(pkg, pkg_path) { |element, path| yield element, path }
+        end
+      end
+
+      # Walkable nodes are the two container types in the UML hierarchy.
+      # Anything else (e.g. a stray Classifier) has no typed collections
+      # to walk.
+      def walkable?(node)
+        node.is_a?(Lutaml::Uml::Package) || node.is_a?(Lutaml::Uml::Document)
+      end
+    end
+  end
+end

--- a/lib/lutaml/uml_repository/exporters/json_exporter.rb
+++ b/lib/lutaml/uml_repository/exporters/json_exporter.rb
@@ -21,6 +21,8 @@ module Lutaml
       # @example Export specific package
       #   exporter.export("model.json", package: "ModelRoot::i-UR::urf")
       class JsonExporter < BaseExporter
+        include Lutaml::Uml::ModelHelpers
+
         # Export repository to JSON format.
         #
         # @param output_path [String] Path to the output JSON file
@@ -150,23 +152,6 @@ module Lutaml
           }
         end
 
-        # Normalize stereotypes to array format.
-        #
-        # @param stereotype [String, Array, nil] The stereotype(s)
-        # @return [Array] Array of stereotypes
-        def normalize_stereotypes(stereotype)
-          return [] unless stereotype
-
-          case stereotype
-          when Array
-            stereotype
-          when String
-            [stereotype]
-          else
-            []
-          end
-        end
-
         # Get class type.
         #
         # @param klass [Object] The class object
@@ -181,15 +166,6 @@ module Lutaml
         # @return [String] The qualified name
         def qualified_name(klass)
           indexes&.dig(:class_to_qname, klass.xmi_id) || klass.name
-        end
-
-        # Extract package path from qualified name.
-        #
-        # @param qname [String] The qualified name
-        # @return [String] The package path
-        def extract_package_path(qname)
-          parts = qname.split("::")
-          parts.size > 1 ? parts[0..-2].join("::") : ""
         end
 
         # Serialize class attributes.

--- a/lib/lutaml/uml_repository/exporters/markdown/class_page_builder.rb
+++ b/lib/lutaml/uml_repository/exporters/markdown/class_page_builder.rb
@@ -14,7 +14,7 @@ module Lutaml
 
           def build(klass, qname)
             type = klass.class.name.split("::").last
-            pkg_path = @link_resolver.extract_package_path(qname)
+            pkg_path = @link_resolver.extract_package_path(qname, default: "ModelRoot")
 
             <<~MARKDOWN
               # #{type}: #{klass.name}

--- a/lib/lutaml/uml_repository/exporters/markdown/link_resolver.rb
+++ b/lib/lutaml/uml_repository/exporters/markdown/link_resolver.rb
@@ -5,6 +5,8 @@ module Lutaml
     module Exporters
       module Markdown
         class LinkResolver
+          include Lutaml::Uml::ModelHelpers
+
           def initialize(indexes)
             @indexes = indexes
           end
@@ -23,11 +25,6 @@ module Lutaml
 
           def qualified_name(klass)
             @indexes&.dig(:class_to_qname, klass.xmi_id) || klass.name
-          end
-
-          def extract_package_path(qname)
-            parts = qname.split("::")
-            parts.size > 1 ? parts[0..-2].join("::") : "ModelRoot"
           end
 
           def sanitize_filename(name)

--- a/lib/lutaml/uml_repository/lazy_repository.rb
+++ b/lib/lutaml/uml_repository/lazy_repository.rb
@@ -198,38 +198,39 @@ module Lutaml
 
       private
 
+      # Map of index_name -> [builder, prerequisites] describing how each
+      # lazy index is constructed. Adding a new index type is a one-line
+      # entry here — no edit to {ensure_index} required.
+      INDEX_BUILDERS = {
+        package_paths:     [->(doc, _idx) { IndexBuilder.build_package_paths(doc) }, []],
+        qualified_names:   [->(doc, _idx) { IndexBuilder.build_qualified_names(doc) }, []],
+        stereotypes:       [->(doc, _idx) { IndexBuilder.build_stereotypes(doc) }, []],
+        inheritance_graph: [->(doc, idx) { IndexBuilder.build_inheritance_graph(doc, idx) },
+                            [:qualified_names]],
+        diagram_index:     [->(doc, idx) { IndexBuilder.build_diagram_index(doc, idx) },
+                            [:package_paths]],
+      }.freeze
+
       # Ensure an index is built.
       #
       # If the index is already built, this method returns immediately.
-      # Otherwise, it builds the index and removes it from the pending list.
+      # Otherwise, it builds the index (and any prerequisites) and removes
+      # it from the pending list.
       #
       # @param index_name [Symbol] The name of the index to ensure
       # @return [void]
-      def ensure_index(index_name) # rubocop:disable Metrics/AbcSize,Metrics/CyclomaticComplexity,Metrics/MethodLength
+      # @raise [ArgumentError] if +index_name+ is not a registered index
+      def ensure_index(index_name)
         return if index_built?(index_name)
 
+        entry = INDEX_BUILDERS[index_name]
+        raise ArgumentError, "Unknown index: #{index_name.inspect}" unless entry
+
+        builder, prerequisites = entry
+        prerequisites.each { |pre| ensure_index(pre) }
+
         puts "Building #{index_name} index..." if $VERBOSE
-
-        case index_name
-        when :package_paths
-          @indexes[:package_paths] = IndexBuilder.build_package_paths(@document)
-        when :qualified_names
-          @indexes[:qualified_names] =
-            IndexBuilder.build_qualified_names(@document)
-        when :stereotypes
-          @indexes[:stereotypes] = IndexBuilder.build_stereotypes(@document)
-        when :inheritance_graph
-          # Requires qualified_names first
-          ensure_index(:qualified_names)
-          @indexes[:inheritance_graph] =
-            IndexBuilder.build_inheritance_graph(@document, @indexes)
-        when :diagram_index
-          # Requires package_paths first
-          ensure_index(:package_paths)
-          @indexes[:diagram_index] =
-            IndexBuilder.build_diagram_index(@document, @indexes)
-        end
-
+        @indexes[index_name] = builder.call(@document, @indexes)
         @index_builders_pending.delete(index_name)
       end
     end

--- a/lib/lutaml/uml_repository/package_exporter.rb
+++ b/lib/lutaml/uml_repository/package_exporter.rb
@@ -37,6 +37,8 @@ module Lutaml
     #   )
     #   exporter.export("model.lur")
     class PackageExporter
+      include Lutaml::Uml::ModelHelpers
+
       # @return [UmlRepository] The repository being exported
       attr_reader :repository
 
@@ -265,7 +267,7 @@ module Lutaml
             "type" => klass.class.name.split("::").last, # Class, DataType, Enum
             "stereotype" => format_stereotype(klass.stereotype),
             "attributes" => build_attributes_list(klass),
-            "package_path" => extract_package_path(qname),
+            "package_path" => extract_package_path(qname, default: "ModelRoot"),
           }
         end
         classes
@@ -296,15 +298,6 @@ module Lutaml
         return stereotype if stereotype.is_a?(String)
 
         stereotype.is_a?(Array) && stereotype.empty? ? nil : stereotype
-      end
-
-      # Extract package path from qualified name
-      #
-      # @param qname [String] Qualified name
-      # @return [String] Package path
-      def extract_package_path(qname)
-        parts = qname.split("::")
-        parts.size > 1 ? parts[0..-2].join("::") : "ModelRoot"
       end
 
       # Count all attributes across all classes

--- a/lib/lutaml/uml_repository/package_loader.rb
+++ b/lib/lutaml/uml_repository/package_loader.rb
@@ -137,13 +137,24 @@ module Lutaml
       end
 
       # Load the Document from the package.
+      # Map of serialization format -> loader. Adding a new format is a
+      # one-line entry here — no edit to {load_document} required.
+      FORMAT_LOADERS = {
+        "yaml"   => ->(zip) { load_yaml_document(zip) },
+        ""       => ->(zip) { load_yaml_document(zip) },
+        "marshal" => ->(zip) { load_marshal_document(zip) },
+      }.freeze
+
+      # Load a Document from a LUR package's serialized form.
+      #
+      # Dispatch is by the format name recorded in +metadata+.
+      # Unrecognized formats raise.
       #
       # @param zip [Zip::File] The ZIP archive
-      # @param metadata [PackageMetadata] The package metadata
+      # @param metadata [PackageMetadata, Hash] The package metadata
       # @return [Lutaml::Uml::Document] The loaded document
       # @raise [RuntimeError] If document is missing or format is unknown
-      def self.load_document(zip, metadata) # rubocop:disable Metrics/MethodLength
-        # Handle both PackageMetadata object and Hash (backward compatibility)
+      def self.load_document(zip, metadata)
         format = if metadata.is_a?(Hash)
                    metadata["serialization_format"] ||
                      metadata[:serialization_format]
@@ -151,14 +162,10 @@ module Lutaml
                    metadata.serialization_format
                  end
 
-        case format.to_s
-        when "yaml", ""
-          load_yaml_document(zip)
-        when "marshal"
-          load_marshal_document(zip)
-        else
-          raise "Unknown serialization format: #{format}"
-        end
+        loader = FORMAT_LOADERS[format.to_s]
+        raise "Unknown serialization format: #{format}" unless loader
+
+        loader.call(zip)
       end
 
       # Load Document from Marshal format (legacy backward compatibility).

--- a/lib/lutaml/uml_repository/presenters/element_presenter.rb
+++ b/lib/lutaml/uml_repository/presenters/element_presenter.rb
@@ -10,6 +10,8 @@ module Lutaml
       #
       # Subclasses must implement: to_text, to_table_row, to_hash
       class ElementPresenter
+        include Lutaml::Uml::ModelHelpers
+
         attr_reader :element, :repository, :context
 
         # @param element [Object] The UML element to present
@@ -75,15 +77,6 @@ module Lutaml
           return text if text.length <= max_length
 
           "#{text[0...(max_length - 3)]}..."
-        end
-
-        # Extract package path from qualified name.
-        #
-        # @param qualified_name [String] Fully qualified name
-        # @return [String] Package path (everything except last component)
-        def extract_package_path(qualified_name)
-          parts = qualified_name.to_s.split("::")
-          parts[0..-2].join("::")
         end
       end
     end

--- a/lib/lutaml/uml_repository/queries/search_query.rb
+++ b/lib/lutaml/uml_repository/queries/search_query.rb
@@ -207,21 +207,22 @@ case_sensitive: false)
           { classes: [], attributes: [], associations: [], total: 0 }
         end
 
+        # Map of searchable entity type -> search method. Adding a new
+        # type is a one-line entry here — no edit to {dispatch_search}
+        # required.
+        SEARCH_TYPES = {
+          class:       :search_classes,
+          attribute:   :search_attributes,
+          association: :search_associations,
+        }.freeze
+
         def dispatch_search(type, query_string, fields:, case_sensitive:)
-          case type
-          when :class
-            search_classes(query_string,
-                           fields: fields,
-                           case_sensitive: case_sensitive)
-          when :attribute
-            search_attributes(query_string,
-                              fields: fields,
-                              case_sensitive: case_sensitive)
-          when :association
-            search_associations(query_string,
-                                fields: fields,
-                                case_sensitive: case_sensitive)
-          end
+          method_name = SEARCH_TYPES[type]
+          return unless method_name
+
+          public_send(method_name, query_string,
+                      fields: fields,
+                      case_sensitive: case_sensitive)
         end
 
         def read_attribute(obj, field)

--- a/lib/lutaml/uml_repository/static_site/configuration.rb
+++ b/lib/lutaml/uml_repository/static_site/configuration.rb
@@ -344,31 +344,59 @@ module Lutaml
           when Hash
             attr
           when String
-            # Try to parse as YAML first
+            # Try to parse as YAML first.
             begin
               parsed = YAML.safe_load(attr, permitted_classes: [Symbol])
               return parsed if parsed.is_a?(Hash)
             rescue StandardError
-              # Fall through to eval if YAML parsing fails
+              # Fall through to Ruby-hash-literal parsing.
             end
 
-            # If the string looks like a Ruby hash (contains =>),
-            # try to evaluate it safely
-            if attr.include?("=>")
-              begin
-                # Use eval in a controlled way - this is safe because we
-                # control the input
-                # The string comes from our own YAML config file
-                parsed = eval(attr) # rubocop:disable Security/Eval
-                return parsed if parsed.is_a?(Hash)
-              rescue StandardError
-                # Fall through to empty hash
-              end
-            end
+            # Fall back to a focused parser for legacy Ruby hash syntax
+            # (e.g. +"key1 => value1, key2 => value2"+). Handles the
+            # common cases without evaluating arbitrary Ruby.
+            return parse_ruby_hash_literal(attr) if attr.include?("=>")
 
             {}
           else
             {}
+          end
+        end
+
+        # Parse a restricted subset of the Ruby hash literal: keys/values
+        # use Ruby scalar literals (String, Symbol, Integer, Float, true,
+        # false, nil). Quotes are honoured; braces are stripped. This
+        # replaces the prior +eval()+ fallback, which could evaluate
+        # arbitrary Ruby.
+        def parse_ruby_hash_literal(attr)
+          body = attr.to_s.gsub(/\A\s*\{|\}\s*\z/, "")
+          return {} if body.empty?
+
+          body.split(",").each_with_object({}) do |pair, hash|
+            key, value = pair.split("=>", 2)
+            next unless key && value
+
+            hash[parse_literal(key.strip)] = parse_literal(value.strip)
+          end
+        rescue StandardError
+          {}
+        end
+
+        # Coerce a token from a Ruby hash literal into its scalar value.
+        # Strings keep their quotes-stripped content; symbols retain their
+        # leading colon; integers, floats, true, false, nil parse to the
+        # matching Ruby type. Anything else stays a string.
+        def parse_literal(token)
+          case token
+          when /\A".*"\z/  then token[1..-2]
+          when /\A'.*'\z/  then token[1..-2]
+          when /\A:/       then token[1..].to_sym
+          when "true"      then true
+          when "false"     then false
+          when "nil"       then nil
+          when /\A-?\d+\z/ then token.to_i
+          when /\A-?\d+\.\d+\z/ then token.to_f
+          else token
           end
         end
       end

--- a/lib/lutaml/uml_repository/static_site/generator.rb
+++ b/lib/lutaml/uml_repository/static_site/generator.rb
@@ -69,23 +69,23 @@ module Lutaml
           end
         end
 
+        # Map of output mode -> strategy class. Adding a new mode is a
+        # one-line entry here — no edit to {resolve_strategy} required.
+        OUTPUT_STRATEGIES = {
+          single_file: Output::VueInlinedStrategy,
+          multi_file:  Output::MultiFileStrategy,
+        }.freeze
+
         def resolve_strategy(options)
           strategy_class = options[:output_strategy]
-          if strategy_class
-            return strategy_class.new(@options[:output],
-                                      config: @config)
-          end
+          return strategy_class.new(@options[:output], config: @config) if strategy_class
 
-          case @options[:mode]
-          when :single_file
-            Output::VueInlinedStrategy.new(@options[:output], config: @config)
-          when :multi_file
-            Output::MultiFileStrategy.new(@options[:output], config: @config)
-          else
-            raise ArgumentError,
-                  "Invalid mode: #{@options[:mode]}. " \
-                  "Use :single_file or :multi_file"
-          end
+          resolved = OUTPUT_STRATEGIES[@options[:mode]]
+          raise ArgumentError,
+                "Invalid mode: #{@options[:mode]}. " \
+                "Use :single_file or :multi_file" unless resolved
+
+          resolved.new(@options[:output], config: @config)
         end
 
         def create_data_transformer


### PR DESCRIPTION
## Summary

Architecture review surfaced five deepening opportunities. This PR ships the three mechanical ones (Strong); the other two (Repository facade, SPA pipeline shape) are interface-shape questions that want a separate grilling session.

Full report: written to `/tmp/architecture-review-20260711.html` (local only, not in repo).

## What's in this PR

### 1. ModelHelpers triple-duplication (candidate 1)

`normalize_stereotypes` and `extract_package_path` were defined five times across the codebase with subtly different semantics. Four consumers (JsonExporter, PackageExporter, LinkResolver, ElementPresenter) had rolled private copies instead of including `Lutaml::Uml::ModelHelpers`.

- Made `ModelHelpers` the single source — its keyword-arg `extract_package_path(qname, default: "")` already covered all call sites.
- Deleted the four private copies; added `include Lutaml::Uml::ModelHelpers` where missing.
- Pass `default: "ModelRoot"` at the two call sites that want it.

Net: -41 LOC of duplication. Locality: wire-format drift is now impossible.

### 2. Open-coded case/when dispatches → registries (candidate 2)

Four sites converted:

| File | Before | After |
|------|--------|-------|
| `LazyRepository#ensure_index` | 6-way `case index_name` | `INDEX_BUILDERS` hash with prerequisite graph |
| `PackageLoader.load_document` | `case format.to_s` | `FORMAT_LOADERS` hash |
| `Generator#resolve_strategy` | `case @options[:mode]` | `OUTPUT_STRATEGIES` hash |
| `SearchQuery#dispatch_search` | `case type` | `SEARCH_TYPES` hash |

Adding a new variant is now one entry in the relevant registry, zero edits to dispatch code. Same pattern already proven in `PresenterFactory`. Bonus: LazyRepository's prerequisite comments are now data, not prose.

### 3. Forbidden patterns (candidate 3)

- **`PackageWalker`** — `respond_to?` × 2 for duck-typing. The file was also syntax-broken (missing `end`s, unbalanced blocks) and unreferenced from anywhere. Rewrote with proper structure, replaced `respond_to?` with explicit `is_a?(Lutaml::Uml::Document|Package)` type checks, added a `TYPES` whitelist before the `public_send` dispatch. File now actually loads.
- **`Configuration#parse_hash_attribute`** — `eval()` on YAML config strings using Ruby `key=>value` hash syntax. Replaced with a focused `parse_ruby_hash_literal` that handles quoted strings, symbols, integers, floats, booleans, nil — the common cases — without evaluating arbitrary Ruby. Same call-site semantics; existing `feature_flags` parsing round-trips correctly.

CLAUDE.md compliance restored: **zero `respond_to?`, zero `eval()` in `lib/`**.

### Supporting changes

- `CLAUDE.md` — refresh stale sections (architecture list, spec-require rules) referencing extracted paths.
- `Gemfile` — switch `lutaml-model` to sibling-path pattern (matching `ea`). Bundler couldn't satisfy the ea/xmi version constraints against the github branch source; local path lets bundler read the gemspec directly.

## Verification

- Full lutaml-uml suite: **754 examples, 0 failures, 103 pending** (pending are pre-existing `xdescribe` skips).
- Configuration specs: **23 examples, 0 failures** (the eval→parser swap is covered here).
- All four registry conversions are covered by existing dispatch specs.

## Deferred (need grilling)

- **Repository — 689-LOC pass-through facade.** Three legitimate answers (method_missing, expose query objects, keep as-is). Wants design discussion.
- **SPA pipeline — 19 implicit-shape serializers.** Introducing a typed `SpaSchema` could give the Vue layer a single contract. Multiple valid designs.

## Test plan

- [ ] CI green on Linux/macOS.
- [ ] Windows known-broken (pre-existing, not from this PR).
- [ ] Rebase-merge with admin if Windows blocks.
